### PR TITLE
possible improvement to if regex?

### DIFF
--- a/system/logic.py
+++ b/system/logic.py
@@ -2,7 +2,7 @@ import re
 
 from core import logging, helpers, function
 
-regexLogicString = re.compile(r'((\"(.*?[^\\])\"|([a-zA-Z0-9]+(\[(.*?)\])+)|([a-zA-Z0-9]+(\((.*?)(\)\)|\)))+)|\[(.*?)\]|([a-zA-Z0-9]*)))\s?( not match | match | not in | in |==|!=|>=|>|<=|<)\s?((\"(.*?[^\\])\"|([a-zA-Z0-9]+(\[(.*?)\])+)|([a-zA-Z0-9]+(\((.*?)(\)\)|\))( |$))+)|\[(.*?)\]|([a-zA-Z0-9]*)))')
+regexLogicString = re.compile(r'((\"(.*?[^\\])\"|([a-zA-Z0-9]+(\[(.*?)\])+)|([a-zA-Z0-9]+(\((.*?)(\)\)|\)))+)|\[(.*?)\]|([a-zA-Z0-9]*)))\s?( not match | match | not in | in |==|!=|>=|>|<=|<)\s?((\"(.*?[^\\])\"|([a-zA-Z0-9]+(\[(.*?)\])+)|([a-zA-Z0-9]+(\((.*?)(\)\)|\))(|$))+)|\[(.*?)\]|([a-zA-Z0-9]*)))')
 regexLogicSafeValidationString = re.compile(r'^(True|False|\(|\)| |or|and|not)*$')
 
 def ifEval(logicString,dicts={},debug=False):


### PR DESCRIPTION
If statements with functions currently pickup an extra space.

if "gi" in lower(data[var][interface]) and lower(data[var][interface]) not in eventData[var][port_list]

The above does not currently work without adding an extra space before the and

if "gi" in lower(data[var][interface])  and lower(data[var][interface]) not in eventData[var][port_list]