### PR TITLE
Feature/event yeld

### DIFF
--- a/core/debug.py
+++ b/core/debug.py
@@ -191,7 +191,12 @@ if jimi.api.webServer:
                                     data = jimi.conduct.dataTemplate()
                         else:
                             t.data = { "flowData" : { "var" : {}, "plugin" : {} } }
-                            events = t.doCheck()
+                            if t.partialResults:
+                                events = []
+                                for event in t.doCheck():
+                                    events.append(event)
+                            else:
+                                events = t.doCheck()
                         maxDuration = t.maxDuration
                     else:
                         t = jimi.action._action(False).getAsClass(sessionData=jimi.api.g.sessionData,id=flow["actionID"])[0]

--- a/core/models/trigger.py
+++ b/core/models/trigger.py
@@ -239,7 +239,7 @@ class _trigger(jimi.db._document):
         # Return the final data value
         return data
 
-    def checkHandler(self):
+    def checkHandler(self,data=None):
         ####################################
         #              Header              #
         ####################################
@@ -247,15 +247,19 @@ class _trigger(jimi.db._document):
         jimi.audit._audit().add("trigger","start",{ "trigger_id" : self._id, "trigger_name" : self.name })
         ####################################
 
-        self.data = { "flowData" : { "var" : {}, "plugin" : {} } }
-        data = None
-        if self.data["flowData"]["var"] or self.data["flowData"]["plugin"]:
-            data = self.data
+        if not data:
+            data = { "flowData" : { "var" : {}, "plugin" : {} } }
+        elif "flowData" not in data:
+            data["flowData"] = { "flowData" : { "var" : {}, "plugin" : {} } }
+        self.data = data
 
         if self.partialResults:
             self.checkAndNotify(data=data)
         else:
             events = self.doCheck()
+            if self.data["flowData"]["var"] or self.data["flowData"]["plugin"]:
+                data["flowData"]["var"] = self.data["flowData"]["var"]
+                data["flowData"]["plugin"] = self.data["flowData"]["plugin"]
             self.notify(events=events,data=data)
         ####################################
         #              Footer              #

--- a/core/models/trigger.py
+++ b/core/models/trigger.py
@@ -98,7 +98,7 @@ class _trigger(jimi.db._document):
                 for loadedConduct in conducts:
                     conductData[loadedConduct._id] = jimi.conduct.copyData(data,copyConductData=True)
 
-                eventIndex = 0
+                eventIndex = 1
                 for events in self.doCheck():
                     if type(events) is not list:
                         events = [events]

--- a/core/models/webui.py
+++ b/core/models/webui.py
@@ -58,7 +58,7 @@ class _properties():
         formData = []
         if classObject.manifest__:
             if len(classObject.manifest__["fields"]) > 0:
-                systemFields = ["_id","name","enabled","log","concurrency","threaded","failOnActionFailure","systemCrashHandler","systemID","startTime","nextCheck","schedule","maxDuration","logicString","varDefinitions","comment"]
+                systemFields = ["_id","name","enabled","log","partialResults","concurrency","threaded","failOnActionFailure","systemCrashHandler","systemID","startTime","nextCheck","schedule","maxDuration","logicString","varDefinitions","comment"]
                 formData.append({"type" : "break", "schemaitem" : "break", "start" : True, "label" : "System"})
                 for field in systemFields:
                     try:


### PR DESCRIPTION
Adds Yield support so that plugin devs can return data to be processed by the flow in parts.

Usage:

Set - partialResults = True
Ensure your using doCheck and return lists using yield

```
class _testFireTrigger(trigger._trigger):
    events = [1]
    partialResults = True

    def doCheck(self):
        for event in self.events:
            yield [event]
```

Debug does support yield but will collect all of the events in advance and not allow for part flow execution. A future change maybe to support this but for now that support is only during normal executions.

It should also be noted that it is impossible to do event counts for eventStats as the total number of events is unknown.

I see this being used by devs going forward to poll APIs in the background while data is passed down the flow to be processed. This will also help with API rate limits as the flow will take some time to complete allowing gaps between calls.

All data types including persistentData, conductData and eventData should work as normal and is stored in memory while yield is executing so to the user nothing changes. 