### PR TITLE
Feature/subflow retry

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -95,15 +95,15 @@ class variableDefineFailure(Exception):
         return "Error: Exception setting variable. var_dict='{0}', trace='{1}'".format(self.varDict,self.trace)
 
 class endWorker(Exception):
-    def __init__(self):
-        pass
+    def __init__(self,data={}):
+        self.data = data
         
     def __str__(self):
         return "Worker end exception raised"
 
 class endFlow(Exception):
-    def __init__(self):
-        pass
+    def __init__(self,data={}):
+        self.data = data
         
     def __str__(self):
         return "Flow end exception raised"

--- a/core/models/conduct.py
+++ b/core/models/conduct.py
@@ -200,10 +200,10 @@ class _conduct(jimi.db._document):
                                 flowDebugSession["actionID"] = jimi.debug.flowDebugSession[flowDebugSession["sessionID"]].startAction(flowDebugSession["eventID"],data["flowData"]["flow_id"],class_.name,copyData(data,copyEventData=True,copyConductData=True,copyPersistentData=True))
                             try:
                                 data["flowData"]["action"] = class_.runHandler(data=data,debug=debug)
-                            except jimi.exceptions.endWorker:
-                                raise jimi.exceptions.endWorker
                             except jimi.exceptions.endFlow:
                                 raise jimi.exceptions.endFlow
+                            except jimi.exceptions.endWorker as e:
+                                raise jimi.exceptions.endWorker(e.data)
                             except Exception as e:
                                 jimi.logging.debug("Error: Action Crashed. actionID={0}, actionName={1}, error={2}".format(class_._id,class_.name,''.join(traceback.format_exception(type(e), e, e.__traceback__))),-1)
                                 if flowDebugSession:

--- a/core/models/trigger.py
+++ b/core/models/trigger.py
@@ -139,8 +139,8 @@ class _trigger(jimi.db._document):
                 jimi.audit._audit().add("trigger","auto_disable",{ "trigger_id" : self._id, "trigger_name" : self.name })
                 self.enabled = False
                 self.update(["enabled"])
-        except jimi.exceptions.endWorker:
-            raise jimi.exceptions.endWorker
+        except jimi.exceptions.endWorker as e:
+            raise jimi.exceptions.endWorker(e.data)
         finally:
             self.startCheck = 0
             self.attemptCount = 0
@@ -224,8 +224,8 @@ class _trigger(jimi.db._document):
                 jimi.audit._audit().add("trigger","auto_disable",{ "trigger_id" : self._id, "trigger_name" : self.name })
                 self.enabled = False
                 self.update(["enabled"])
-        except jimi.exceptions.endWorker:
-            raise jimi.exceptions.endWorker
+        except jimi.exceptions.endWorker as e:
+            raise jimi.exceptions.endWorker(e.data)
         finally:
             self.startCheck = 0
             self.attemptCount = 0

--- a/system/install.py
+++ b/system/install.py
@@ -11,7 +11,7 @@ import logging
 import jimi
 
 # Current System Version
-systemVersion = 3.1247
+systemVersion = 3.13
 
 # Initialize 
 dbCollectionName = "system"
@@ -322,6 +322,7 @@ def systemInstall():
 
     # subFlow
     jimi.model.registerModel("subFlow","_subFlow","_action","system.models.subFlow")
+    jimi.model.registerModel("subFlowReturn","_subFlowReturn","_action","system.models.subFlow")
 
     # global
     jimi.model.registerModel("global","_global","_document","system.models.global")
@@ -574,7 +575,8 @@ def systemUpgrade(currentVersion):
         jimi.revision._revision()._dbCollection.create_index([("objectID", 1),("classID", 1)])
         jimi.audit._audit()._dbCollection.create_index([("eventSource", 1),("eventType", 1)])
 
-    if currentVersion < 3.1247:
+    if currentVersion < 3.13:
+        jimi.model.registerModel("subFlowReturn","_subFlowReturn","_action","system.models.subFlow")
         loadSystemManifest()
 
     return True

--- a/system/install.py
+++ b/system/install.py
@@ -11,7 +11,7 @@ import logging
 import jimi
 
 # Current System Version
-systemVersion = 3.1246
+systemVersion = 3.1247
 
 # Initialize 
 dbCollectionName = "system"
@@ -573,5 +573,8 @@ def systemUpgrade(currentVersion):
         logging.info("Creating indexes...")
         jimi.revision._revision()._dbCollection.create_index([("objectID", 1),("classID", 1)])
         jimi.audit._audit()._dbCollection.create_index([("eventSource", 1),("eventType", 1)])
+
+    if currentVersion < 3.1247:
+        loadSystemManifest()
 
     return True

--- a/system/models/subFlow.py
+++ b/system/models/subFlow.py
@@ -27,8 +27,12 @@ class _subFlow(jimi.action._action):
 
 		trigger = jimi.trigger._trigger().getAsClass(id=triggerID)
 		if len(trigger) == 1:
+			subflowResult = True
 			trigger = trigger[0]
 			finalData = trigger.notify(events,tempData)
+			for scope in ["persistentData","conductData","flowData","eventData"]:
+				if "subflowResult" in finalData[scope]["var"]:
+					subflowResult = finalData[scope]["var"]["subflowResult"]
 			if self.mergeFinalDataValue:
 				data["flowData"]["action"] = finalData["flowData"]["action"]
 				data["flowData"]["var"] = finalData["flowData"]["var"]
@@ -42,4 +46,4 @@ class _subFlow(jimi.action._action):
 		else:
 			return { "result" : False, "rc" : 5, "msg" : "Unable to find the specified triggerID={0}".format(triggerID) }
 
-		return { "result" : True, "rc" : 0 }
+		return { "result" : subflowResult, "rc" : 0 }

--- a/system/models/subFlow.py
+++ b/system/models/subFlow.py
@@ -9,6 +9,8 @@ class _subFlow(jimi.action._action):
 	mergeFinalDataValue = False 
 	mergeFinalEventValue = False
 	mergeFinalConductValue = False
+	maxRetries = 0
+	retryDelay = 0
 
 	def doAction(self,data):
 		triggerID = jimi.helpers.evalString(self.triggerID,{"data" : data["flowData"]})

--- a/system/system.json
+++ b/system/system.json
@@ -1,7 +1,7 @@
 {
     "name" : "system",
     "author" : "system",
-    "version" : 3.1247,
+    "version" : 3.13,
     "categories" : ["system"],
     "description" : "System installed triggers and actions.",
     "icon" : null,
@@ -648,6 +648,17 @@
                         "(string)" : { "description" : "A message that outlines additional information about the result." }
                     }
                 }
+            }
+        },
+        "subFlowReturn" : {
+            "display_name" : "subFlowReturn",
+            "className" : "_subFlowReturn",
+            "class_location" : "system.models.subFlow",
+            "description" : "Returns True|False from a running subFlow. ",
+            "fields" : [
+                { "schema_item" : "subFlowResult", "schema_value" : "subFlowResult", "type" : "checkbox", "label" : "subFlowResult", "description" : "The True|False result to return from the subFlow.", "required" : true, "jimi_syntax" : false }
+            ],
+            "data_out" : {
             }
         },
         "generatePassword" : {

--- a/system/system.json
+++ b/system/system.json
@@ -1,7 +1,7 @@
 {
     "name" : "system",
     "author" : "system",
-    "version" : 3.1152,
+    "version" : 3.1247,
     "categories" : ["system"],
     "description" : "System installed triggers and actions.",
     "icon" : null,
@@ -617,7 +617,9 @@
                 { "schema_item" : "customEventsList", "schema_value" : "customEventsList", "type" : "checkbox", "label" : "customEventsList", "description" : "When True and customEventsValue is also False then it overrides the existing event with the list provided within eventsList.", "required" : false, "jimi_syntax" : false },
                 { "schema_item" : "eventsList", "schema_value" : "eventsList", "type" : "json-input", "label" : "eventsList", "description" : "When customEventsList is True and customEventsValue is also False this list overrides the existing event value.", "required" : false, "jimi_syntax" : true },
                 { "schema_item" : "mergeFinalEventValue", "schema_value" : "mergeFinalEventValue", "type" : "checkbox", "label" : "mergeFinalEventValue", "description" : "When True the last data value from the triggered flow will be merged with the current data value on this flow.", "required" : false, "jimi_syntax" : true },
-                { "schema_item" : "mergeFinalConductValue", "schema_value" : "mergeFinalConductValue", "type" : "checkbox", "label" : "mergeFinalConductValue", "description" : "When True the last data value from the triggered flow will be merged with the current data value on this flow.", "required" : false, "jimi_syntax" : true }
+                { "schema_item" : "mergeFinalConductValue", "schema_value" : "mergeFinalConductValue", "type" : "checkbox", "label" : "mergeFinalConductValue", "description" : "When True the last data value from the triggered flow will be merged with the current data value on this flow.", "required" : false, "jimi_syntax" : true },
+                { "schema_item" : "maxRetries", "schema_value" : "maxRetries", "type" : "input", "label" : "maxRetries", "description" : "If the subflow fails, how many times to retry the flow", "required" : false, "jimi_syntax" : true },
+                { "schema_item" : "retryDelay", "schema_value" : "retryDelay", "type" : "input", "label" : "retryDelay", "description" : "The time to wait between retrying a flow", "required" : false, "jimi_syntax" : true }
             ],
             "data_out" : {
                 "result" : { 


### PR DESCRIPTION
Allows for the retrying of subflows. Currently there are two values that can now be set; maxRetries and retryDelay.
![image](https://user-images.githubusercontent.com/14958920/143852885-0802a758-ab4c-4d26-9cea-dc1364ec1c6b.png)
This allows a user to ask jimi to retry the subflow but also wait a certain period of time between each. User's will have to keep in mind the total trigger time.

In order for subflow to know whether it was a success or not, currently users can add the following varDefinition anywhere in the child flow and this will be checked by subflow:
**{"subflowResult":{"value":false|true}}**
```
if "subflowResult" in finalData["flowData"]["var"]:
	subflowResult = finalData["flowData"]["var"]["subflowResult"]
```
