### PR TITLE
Unit selection support

### DIFF
--- a/core/models/webui.py
+++ b/core/models/webui.py
@@ -89,6 +89,8 @@ class _properties():
                             field["textbox"] = field["value"]
                         elif field["type"] == "dropdown":
                             field["current"] = field["value"]
+                        if field["type"] == "unit-input":
+                            field["currentunit"] = getattr(classObject,field["unitschema"])
                         field["tooltip"] = field["description"]
                         formData.append(field)
                 formData.append({"type" : "break", "schemaitem" : "break", "start" : False, "label" : classObject.name})

--- a/web/build/static/javascript/helpers.js
+++ b/web/build/static/javascript/helpers.js
@@ -192,8 +192,7 @@ function buildForm(fromData) {
 
             var $cell = $('<td>');
             $cell.append($('<input class="inputFullWidth theme-panelTextbox-34">').attr({type: 'text', value: fromData[objectItem]["textbox"], current: fromData[objectItem]["textbox"], required: required, id: "properties_items"+fromData[objectItem]["schemaitem"], key: fromData[objectItem]["schemaitem"], tag: "formItem"}));
-            var $select =$('<select class="inputFullWidth theme-panelTextArea-14">').attr({type: 'dropdown', required: required, id: "properties_items"+fromData[objectItem]["selectedunit"], key: fromData[objectItem]["unitschema"], tag: "formItem"});
-
+            var $select =$('<select class="inputFullWidth theme-panelTextArea-14">').attr({type: 'dropdown', required: required, id: "properties_items"+fromData[objectItem]["unitschema"], key: fromData[objectItem]["unitschema"], tag: "formItem"});
             for (var i=0; i< fromData[objectItem]["units"].length;i++){
                 $select.append($('<option>').attr({value: fromData[objectItem]["units"][i]}).text(fromData[objectItem]["units"][i]));
             }


### PR DESCRIPTION
Added support for unit selection such as below.
The older version of jimi supported this with the UI overloading but with the new manifest files it is not currently possible without this change:
![image](https://user-images.githubusercontent.com/14958920/153395526-a33b8694-3e3f-479c-b117-58eb06b9e846.png)

Example in manifest file:
```
          {
               "schema_item": "searchStart",
               "schema_value": "searchStart",
               "type": "unit-input",
               "label": "searchStart",
               "description": "",
               "unitschema": "startUnits",
               "currentunit":"",
               "units": ["seconds","minutes","hours","days","weeks","months","years"]
            }
```