### PR TITLE
B1scuit thi3f subflow bugfix

### DIFF
--- a/core/models/conduct.py
+++ b/core/models/conduct.py
@@ -145,7 +145,7 @@ class _conduct(jimi.db._document):
             flowDebugSession["eventID"] = jimi.debug.flowDebugSession[flowDebugSession["sessionID"]].startEvent(data["flowData"]["trigger_name"],data["flowData"]["event"],data)
         processQueue = []
         currentFlowTag = ""
-        data["flowData"]["conductID"] = self._id
+        data["flowData"]["conduct_id"] = self._id
         data["flowData"]["action"] = { "result" : True, "rc" : 1337 }
         flowObjectsUsed = []
         exitType = None

--- a/system/models/subFlow.py
+++ b/system/models/subFlow.py
@@ -24,6 +24,7 @@ class _subFlow(jimi.action._action):
 		else:
 			tempData = jimi.conduct.copyData(jimi.conduct.dataTemplate(data,keepEvent=True))
 		tempData["flowData"]["callingTriggerID"] = data["flowData"]["trigger_id"]
+		currentConduct = data["persistentData"]["system"]["conduct"]
 
 		if self.customEventsValue:
 			events = jimi.helpers.evalString(self.eventsValue,{"data" : data["flowData"]})
@@ -62,8 +63,10 @@ class _subFlow(jimi.action._action):
 				else:
 					break
 			else:
+				data["persistentData"]["system"]["conduct"] = currentConduct
 				return { "result" : False, "rc" : 5, "msg" : "Unable to find the specified triggerID={0}".format(triggerID) }
 
+		data["persistentData"]["system"]["conduct"] = currentConduct
 		return { "result" : subflowResult, "rc" : 0 }
 
 class _subFlowReturn(jimi.action._action):


### PR DESCRIPTION
Bugfix for when a ForEach is used in a flow with the new subflow object. Because of the way conduct ID is overwritten this causes issues with how ForEach is then able to continue the flow.
Also adjusts the keyname of `conductID` to `conduct_id` to keep it standard across all output.
The following plugins will need adjusting to fix this adjustment of keynames:

- Event
- Choice